### PR TITLE
Rename ApplicationError to ProtocolError

### DIFF
--- a/src/errors.h
+++ b/src/errors.h
@@ -21,12 +21,12 @@ using namespace std::literals;
 
 namespace tasknow::errors {
 
-struct ApplicationError{
+struct ProtocolError{
     std::string message{};
 };
 
-struct UnrecoverableApplicationError: ApplicationError {};
-struct WarningApplicationError: ApplicationError {};
+struct UnrecoverableProtocolError: ProtocolError {};
+struct WarningProtocolError: ProtocolError {};
 
 struct LinuxError{
     int code{0};
@@ -58,15 +58,15 @@ auto log_error_to_stdout(E error) -> void
     ) << std::endl;
 }
 
-template <typename E> requires std::is_base_of_v<ApplicationError, E>
+template <typename E> requires std::is_base_of_v<ProtocolError, E>
 auto log_error_to_stdout(E error) -> void
 {
     std::string error_level{"OTHER"};
 
-    if constexpr (std::same_as<E, UnrecoverableApplicationError>) {
+    if constexpr (std::same_as<E, UnrecoverableProtocolError>) {
         error_level = "ERROR";
     }
-    if constexpr (std::same_as<E, WarningApplicationError>) {
+    if constexpr (std::same_as<E, WarningProtocolError>) {
         error_level = "WARNING";
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ int main()
     } catch (tasknow::errors::LinuxError& error) {
         tasknow::errors::log_error_to_stdout(error);
         return EXIT_FAILURE;
-    } catch (tasknow::errors::ApplicationError& error) {
+    } catch (tasknow::errors::ProtocolError& error) {
         tasknow::errors::log_error_to_stdout(error);
         return EXIT_FAILURE;
     }

--- a/src/serverd.cpp
+++ b/src/serverd.cpp
@@ -39,7 +39,7 @@ auto init(
 
     int max_sock_path_length = sizeof(sockaddr_un::sun_path) / sizeof(char);
     if (std::ssize(sock_path) > max_sock_path_length) {
-        throw errors::UnrecoverableApplicationError{
+        throw errors::UnrecoverableProtocolError{
             std::format("Max sock_path lenght is {}", max_sock_path_length)
         };
     }
@@ -235,7 +235,7 @@ auto handle_request(int* client_sock, Query_method query_method) -> void
         query_method < Query_method::EnumStart
         || query_method >= Query_method::EnumEnd
     ) {
-        throw errors::WarningApplicationError{
+        throw errors::WarningProtocolError{
             "Unknown query method."
         };
     }
@@ -335,7 +335,7 @@ auto serve(std::string_view sock_path, int backlog_size) -> void
                 close(client_sock);
             }
             throw error;
-        } catch (errors::WarningApplicationError& error) {
+        } catch (errors::WarningProtocolError& error) {
             errors::log_error_to_stdout(error);
             if (client_sock != ErrorCode) {
                 close(client_sock);


### PR DESCRIPTION
Tasknow currently has no application layer, and errors named ApplicationError are used for protocol errors. So I renamed ApplicationError to ProtocolError instead of adding a new one.