### PR TITLE
[serverd] extract receiving of the data into a separate function

### DIFF
--- a/src/request_handler.cpp
+++ b/src/request_handler.cpp
@@ -22,6 +22,44 @@
 
 namespace tasknow::request_handler {
 
+auto receive_data(
+    int* client_sock,
+    void* buff,
+    const std::size_t size
+) -> ssize_t {
+    for (int i=1; i<=3; i++) {
+        ssize_t message_length{recv(*client_sock, buff, size, 0)};
+        if (message_length == ErrorCode) {
+            switch (errno) {
+                case EINTR:
+                    if (i==3) {
+                        throw errors::WarningLinuxError{
+                            errno,
+                            "recv(2)",
+                            "The receive was interrupted by delivery of a signal before any data was available."
+                        };
+                    }
+                    continue;
+
+                case ECONNREFUSED:
+                    throw errors::WarningLinuxError{
+                        errno,
+                        "recv(2)",
+                        "A remote host refused to allow the network connection (typically because it is not running the requested service)."
+                    };
+
+                default:
+                    throw errors::UnrecoverableLinuxError{
+                        errno,
+                        "recv(2)",
+                        std::strerror(errno) // NOLINT(concurrency-mt-unsafe)
+                    };
+            }
+        }
+        return message_length;
+    }
+}
+
 auto send_response(
     int* client_sock,
     unsigned char* buff,

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -17,6 +17,12 @@
 
 namespace tasknow::request_handler {
 
+auto receive_data(
+    int* client_sock,
+    void* buff,
+    const std::size_t size
+) -> ssize_t;
+
 auto send_response(
     int* client_sock,
     unsigned char* buff,

--- a/src/serverd.cpp
+++ b/src/serverd.cpp
@@ -199,36 +199,9 @@ auto recieve_method(int* client_sock) -> Query_method
 {
     Query_method query_method{Query_method::EnumEnd};
 
-    for (int i=1; i<=3; i++) {
-        if (recv(*client_sock, &query_method, BytesForSize, 0) == ErrorCode) {
-            switch (errno) {
-                case EINTR:
-                    if (i==3) {
-                        throw errors::WarningLinuxError{
-                            errno,
-                            "recv(2)",
-                            "The receive was interrupted by delivery of a signal before any data was available."
-                        };
-                    }
-                    continue;
+    request_handler::receive_data(client_sock, &query_method, BytesForSize);
 
-                case ECONNREFUSED:
-                    throw errors::WarningLinuxError{
-                        errno,
-                        "recv(2)",
-                        "A remote host refused to allow the network connection (typically because it is not running the requested service)."
-                    };
-
-                default:
-                    throw errors::UnrecoverableLinuxError{
-                        errno,
-                        "recv(2)",
-                        std::strerror(errno) // NOLINT(concurrency-mt-unsafe)
-                    };
-            }
-        }
-        return query_method;
-    }
+    return query_method;
 }
 
 auto handle_request(

--- a/src/serverd.cpp
+++ b/src/serverd.cpp
@@ -195,7 +195,7 @@ auto get_peer_name(
     return {client_addr->sun_path};
 }
 
-auto recieve_method(int* client_sock) -> Query_method
+auto get_request_method(int* client_sock) -> Query_method
 {
     Query_method query_method{Query_method::EnumEnd};
 

--- a/src/serverd.h
+++ b/src/serverd.h
@@ -49,7 +49,7 @@ auto get_peer_name(
     socklen_t* addr_len
 ) -> std::string;
 
-auto recieve_method(int* client_sock) -> Query_method;
+auto get_request_method(int* client_sock) -> Query_method;
 
 auto handle_request(
     int* client_sock,


### PR DESCRIPTION
C++ sources:
- Extract receiving of the data from client into a separate serverd function
- Rename the recieve_method() function to the get_request_method()